### PR TITLE
Update RequestCriteria.php - Fix bug with singularising table names

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -135,7 +135,7 @@ class RequestCriteria implements CriteriaInterface
                      * ex.
                      * products -> product_id
                      */
-                    $prefix = rtrim($sortTable, 's');
+                    $prefix = str_singular($sortTable);
                     $keyName = $table.'.'.$prefix.'_id';
                 }
 


### PR DESCRIPTION
Correct bug with singularising the table names as the current one will not work for all words for example countries turns to countrie instead of country.